### PR TITLE
Fix Decoding Elements with 0 As Content

### DIFF
--- a/src/Support/JsonSimpleXMLElementDecorator.php
+++ b/src/Support/JsonSimpleXMLElementDecorator.php
@@ -135,7 +135,7 @@ class JsonSimpleXMLElementDecorator implements JsonSerializable
         }
 
         // return empty elements as NULL (self-closing or empty tags)
-        if (! $array) {
+        if (! $array && $array != '0') {
             $array = null;
         }
 

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -93,6 +93,13 @@ final class ExampleTest extends TestCase
         static::assertSame(['alias' => 'jdoe'], $arr);
     }
 
+    public function testDecodeArrayWithZeroAsContentFromXml()
+    {
+        $arr = LaravelXml::decode('<document><alias>0</alias></document>');
+
+        static::assertSame(['alias' => '0'], $arr);
+    }
+
     public function testIsValidXmlStr()
     {
         $isValid = LaravelXml::is_valid('');


### PR DESCRIPTION
Fix an issue where elements with `0` as content  i.e. `<foo>0</foo>` being decoded to `null` instead of `0`.

### Steps to reproduce
```
LaravelXml::decode('<document><foo>0</foo></document>');
```
### Expected result
```
[
  "foo" => "0"
]
```
### Actual result
```
[
  "foo" => null
]
```